### PR TITLE
梳理代码核心调用链路

### DIFF
--- a/agent-tools-call-chain-analysis.md
+++ b/agent-tools-call-chain-analysis.md
@@ -1,0 +1,220 @@
+# Agent对Tools调用的核心链路分析
+
+## 概述
+
+这个代码库实现了一个基于Claude AI的对话系统，其中Agent可以调用各种工具(Tools)来完成任务。本文档详细梳理了从用户请求到工具执行的完整调用链路。
+
+## 核心架构组件
+
+### 1. Tool 接口定义 (`src/Tool.ts`)
+```typescript
+export interface Tool {
+  name: string
+  description?: string
+  inputSchema: z.ZodObject<any>
+  inputJSONSchema?: Record<string, unknown>
+  prompt: (options: { dangerouslySkipPermissions: boolean }) => Promise<string>
+}
+```
+
+### 2. 工具注册与管理 (`src/tools.ts`)
+- **工具分类**：
+  - 基础工具：AgentTool, BashTool, FileReadTool, FileEditTool等
+  - 只读工具：通过`isReadOnly()`方法标识
+  - 内存工具：MemoryReadTool, MemoryWriteTool (仅Anthropic内部使用)
+  - MCP工具：通过`getMCPTools()`动态加载
+  - 架构工具：ArchitectTool (需要配置启用)
+
+- **工具获取函数**：
+  - `getAllTools()`: 获取所有基础工具
+  - `getTools(enableArchitect?)`: 获取启用的工具(包括MCP工具)
+  - `getReadOnlyTools()`: 获取只读工具
+
+## 主要调用链路
+
+### 1. 查询处理流程 (`src/query.ts`)
+
+```
+用户请求 → query() → querySonnet() → Claude API → 工具调用决策
+```
+
+#### 核心函数：`query()`
+- **输入参数**：
+  - `messages`: 消息历史
+  - `systemPrompt`: 系统提示词
+  - `context`: 上下文信息
+  - `canUseTool`: 工具权限检查函数
+  - `toolUseContext`: 工具使用上下文
+
+- **处理流程**：
+  1. 格式化系统提示词和上下文
+  2. 调用`querySonnet()`与Claude API交互
+  3. 处理二进制反馈(如果启用)
+  4. 检查响应中的工具调用请求
+  5. 执行工具调用(并发或串行)
+  6. 递归处理后续对话
+
+### 2. 工具执行流程
+
+#### 2.1 工具调用决策
+```
+Assistant Response → 检查tool_use块 → 提取工具调用信息
+```
+
+#### 2.2 工具执行方式选择
+- **并发执行**：当所有工具都是只读时(`runToolsConcurrently`)
+- **串行执行**：包含写操作工具时(`runToolsSerially`)
+
+#### 2.3 单个工具执行流程 (`runToolUse`)
+```
+工具调用请求 → 工具存在性检查 → 输入验证 → 权限检查 → 工具执行 → 结果返回
+```
+
+### 3. 权限和验证流程
+
+#### 3.1 输入验证
+1. **Zod Schema验证**：`tool.inputSchema.safeParse(input)`
+2. **工具特定验证**：`tool.validateInput?.(normalizedInput, context)`
+3. **输入标准化**：`normalizeToolInput(tool, input)`
+
+#### 3.2 权限检查
+```
+shouldSkipPermissionCheck → canUseTool(tool, input, context) → 权限结果
+```
+
+### 4. 具体工具实现示例
+
+#### 4.1 AgentTool (`src/tools/AgentTool/AgentTool.tsx`)
+```
+用户任务 → AgentTool.call() → 创建子Agent → 递归query() → 返回执行结果
+```
+
+**特点**：
+- 创建新的消息序列
+- 使用独立的工具集合
+- 支持日志记录和进度追踪
+- 可以递归调用其他工具
+
+#### 4.2 文件操作工具
+- **FileReadTool**: 读取文件内容
+- **FileEditTool**: 编辑文件
+- **FileWriteTool**: 写入文件
+
+#### 4.3 系统工具
+- **BashTool**: 执行shell命令
+- **GrepTool**: 文件内容搜索
+- **LSTool**: 目录列表
+
+### 5. 上下文管理 (`src/context.ts`)
+
+#### 5.1 上下文信息收集
+```
+getContext() → 收集多种上下文信息 → 缓存结果
+```
+
+**包含信息**：
+- Git状态 (`getGitStatus`)
+- 目录结构 (`getDirectoryStructure`)
+- README文件内容
+- 代码风格配置
+- KODING.md文件
+- 项目配置
+
+#### 5.2 上下文使用
+- 系统提示词格式化：`formatSystemPromptWithContext(systemPrompt, context)`
+- 为Claude提供项目相关信息
+
+### 6. 消息流转和状态管理
+
+#### 6.1 消息类型
+```typescript
+type Message = UserMessage | AssistantMessage | ProgressMessage
+```
+
+#### 6.2 消息处理流程
+```
+原始消息 → normalizeMessagesForAPI() → Claude API → 响应解析 → 消息归一化
+```
+
+#### 6.3 进度追踪
+- **ProgressMessage**: 工具执行过程中的中间状态
+- **工具使用计数**: 统计工具调用次数
+- **性能指标**: 执行时间、token使用量
+
+## 关键设计模式
+
+### 1. 生成器模式 (Generator Pattern)
+- 工具执行使用`async function*`
+- 支持流式结果输出
+- 可以yield进度信息和最终结果
+
+### 2. 中止信号模式 (AbortController Pattern)
+- 每个工具调用都支持中止
+- 优雅处理用户取消操作
+
+### 3. 权限检查模式
+- 分层权限验证
+- 可配置的权限跳过选项
+- 用户交互式权限确认
+
+### 4. 缓存模式 (Memoization)
+- 工具列表缓存：`memoize(getTools)`
+- 上下文信息缓存：`memoize(getContext)`
+- 避免重复计算
+
+## 错误处理和日志
+
+### 1. 错误分类
+- **工具不存在错误**: `No such tool available`
+- **输入验证错误**: `InputValidationError`
+- **权限拒绝错误**: 权限检查失败
+- **执行错误**: 工具执行过程中的异常
+
+### 2. 日志记录
+- **事件追踪**: 使用statsig进行工具使用统计
+- **消息日志**: 完整的消息序列记录
+- **性能指标**: 执行时间、token消耗等
+
+### 3. 错误恢复
+- 工具执行失败时返回错误信息给Claude
+- 支持重试机制
+- 优雅降级处理
+
+## 扩展机制
+
+### 1. MCP (Model Context Protocol) 工具
+- 动态加载外部工具
+- 标准化的工具接口
+- 支持第三方工具集成
+
+### 2. 自定义工具开发
+- 实现Tool接口
+- 注册到工具列表
+- 配置权限和验证逻辑
+
+## 性能优化
+
+### 1. 并发执行
+- 只读工具并发执行
+- 最大并发数限制：`MAX_TOOL_USE_CONCURRENCY = 10`
+
+### 2. 缓存策略
+- 工具列表缓存
+- 上下文信息缓存
+- 减少重复计算
+
+### 3. 资源管理
+- 及时中止不需要的操作
+- 内存友好的流式处理
+
+## 总结
+
+该系统通过清晰的分层架构实现了灵活的工具调用机制：
+
+1. **工具抽象层**: 统一的Tool接口定义
+2. **调用管理层**: query函数协调整个调用流程
+3. **权限控制层**: 多层次的安全检查
+4. **执行引擎层**: 并发/串行执行策略
+5. **上下文管理层**: 丰富的环境信息提供
+
+这种设计既保证了系统的安全性和稳定性，又提供了良好的扩展性和性能。


### PR DESCRIPTION
Add `agent-tools-call-chain-analysis.md` to document the agent's core call chain and tool invocation.